### PR TITLE
Feat calculo resultados

### DIFF
--- a/alembic/versions/84f17ee79218_upgrade_test_session_columns.py
+++ b/alembic/versions/84f17ee79218_upgrade_test_session_columns.py
@@ -29,10 +29,10 @@ def upgrade() -> None:
     sa.Column('child_sex', sa.String(length=1), nullable=False),
     sa.Column('test_sender', sa.String(), nullable=False),
     sa.Column('test_reason', sa.String(), nullable=False),
-    sa.Column('date_time_of_answer', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+    sa.Column('date_time_of_answer', sa.DateTime(timezone=True), nullable=True),
     sa.Column('answers', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
     sa.Column('test_results', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-    sa.Column('calculate_test_results_timestamp', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('calculate_test_results_time_taken', sa.Integer(), nullable=True),
     sa.PrimaryKeyConstraint('id'),
     sa.UniqueConstraint('child_id'),
     schema='questionnaires'

--- a/src/modules/questionnaires/api/questionnaires/questionnaires_router.py
+++ b/src/modules/questionnaires/api/questionnaires/questionnaires_router.py
@@ -7,8 +7,14 @@ from fastapi_injector import Injected
 from mediatr import Mediator
 
 from src.common.api.authorization import psychologist_with_cedula
+from src.common.domain.value_objects.cedula import Cedula
+from src.modules.questionnaires.api.questionnaires.test_session_dto import TestSessionDto
+from src.modules.questionnaires.application.interactors.get_test_Session_by_id.get_test_Session_by_id_query import \
+    GetTestSessionByIdQuery
 from src.modules.questionnaires.application.interactors.get_test_session_id.get_test_session_id_query import \
     GetTestSessionIdQuery
+from src.modules.questionnaires.application.interactors.get_test_session_list.get_test_session_list_query import \
+    GetTestSessionListQuery
 from src.modules.questionnaires.application.invitation_link.invitation_link_provider import InvitationLinkProvider
 
 router = APIRouter(prefix="/questionnaires", tags=["Questionnaires"])
@@ -30,5 +36,27 @@ async def get_token(child_id: int, psychologist_cedula: int, mediator: Mediator 
             # Generate invitation link
             token = InvitationLinkProvider.generate_token(test_session_id)
             return f"{os.getenv("GAME_URL")}/?token={token}"
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/{psychologist_cedula}/test_sessions", dependencies=[Security(psychologist_with_cedula)])
+async def get_test_sessions(psychologist_cedula: int, mediator: Mediator = Injected(Mediator)):
+    try:
+        query = GetTestSessionListQuery(
+            cedula=Cedula(str(psychologist_cedula))
+        )
+        return await mediator.send_async(query)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/resultado/{test_id}")
+async def get_test_sessions(test_id: int, mediator: Mediator = Injected(Mediator)):
+    try:
+        query = GetTestSessionByIdQuery(
+            test_id=test_id
+        )
+        return await mediator.send_async(query)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/src/modules/questionnaires/api/questionnaires/test_session_dto.py
+++ b/src/modules/questionnaires/api/questionnaires/test_session_dto.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class TestSessionDto:
+    test_id: int
+    child_id: int
+    child_name: str
+    psychologist_cedula: str
+    child_age: int
+    scholar_grade: int
+    child_sex: str
+    date_time_of_answer: str
+    answers_set: List[dict]
+
+

--- a/src/modules/questionnaires/api/questionnaires/test_session_dto.py
+++ b/src/modules/questionnaires/api/questionnaires/test_session_dto.py
@@ -5,13 +5,10 @@ from typing import List
 @dataclass
 class TestSessionDto:
     test_id: int
-    child_id: int
     child_name: str
-    psychologist_cedula: str
     child_age: int
     scholar_grade: int
     child_sex: str
     date_time_of_answer: str
-    answers_set: List[dict]
 
 

--- a/src/modules/questionnaires/api/questionnaires/test_session_result_dto.py
+++ b/src/modules/questionnaires/api/questionnaires/test_session_result_dto.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class ResultTestSessionDto:
+    test_id: int
+    child_id: int
+    child_name: str
+    psychologist_cedula: str
+    child_age: int
+    scholar_grade: int
+    child_sex: str
+    test_sender: str
+    test_reason: str
+    date_time_of_answer: str
+    answers_set: List[dict]
+    test_results: List[dict]

--- a/src/modules/questionnaires/application/integration_events_handlers/child_added_event_handler.py
+++ b/src/modules/questionnaires/application/integration_events_handlers/child_added_event_handler.py
@@ -32,9 +32,7 @@ class ChildAddedEventHandler(IntegrationEventHandler[ChildAddedEvent, None]):
                 scholar_grade=event.scholar_grade,
                 child_sex=event.sex,
                 test_sender=event.test_sender,
-                test_reason=event.test_reason,
-                date_time_of_answer=None
-            )
+                test_reason=event.test_reason)
         )
         return test_id
 

--- a/src/modules/questionnaires/application/integration_events_handlers/child_added_event_handler.py
+++ b/src/modules/questionnaires/application/integration_events_handlers/child_added_event_handler.py
@@ -32,7 +32,8 @@ class ChildAddedEventHandler(IntegrationEventHandler[ChildAddedEvent, None]):
                 scholar_grade=event.scholar_grade,
                 child_sex=event.sex,
                 test_sender=event.test_sender,
-                test_reason=event.test_reason
+                test_reason=event.test_reason,
+                date_time_of_answer=None
             )
         )
         return test_id

--- a/src/modules/questionnaires/application/interactors/get_test_Session_by_id/get_test_Session_by_id_query.py
+++ b/src/modules/questionnaires/application/interactors/get_test_Session_by_id/get_test_Session_by_id_query.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+from src.common.application.query import Query
+
+
+@dataclass(frozen=True)
+class GetTestSessionByIdQuery(Query[str]):
+    test_id: int

--- a/src/modules/questionnaires/application/interactors/get_test_Session_by_id/get_test_Session_by_id_query_handler.py
+++ b/src/modules/questionnaires/application/interactors/get_test_Session_by_id/get_test_Session_by_id_query_handler.py
@@ -1,0 +1,18 @@
+from injector import Inject
+
+from src.common.application.query_handler import QueryHandler
+from src.modules.questionnaires.application.interactors.get_test_Session_by_id.get_test_Session_by_id_query import \
+    GetTestSessionByIdQuery
+from src.modules.questionnaires.application.interactors.get_test_Session_by_id.get_test_Session_by_id_query_service import \
+    TestSessionByIdQueryService
+
+
+class GetTestSessionByIdQueryHandler(QueryHandler[GetTestSessionByIdQuery, str]):
+    def __init__(
+            self,
+            test_session_by_id_query_service: Inject[TestSessionByIdQueryService]
+    ):
+        self.__test_session_by_id_query_service = test_session_by_id_query_service
+
+    async def handle(self, query: GetTestSessionByIdQuery) -> str:
+        return await self.__test_session_by_id_query_service.execute_async(query)

--- a/src/modules/questionnaires/application/interactors/get_test_Session_by_id/get_test_Session_by_id_query_service.py
+++ b/src/modules/questionnaires/application/interactors/get_test_Session_by_id/get_test_Session_by_id_query_service.py
@@ -1,0 +1,7 @@
+from abc import ABC
+
+from src.common.application.query_service import QueryService
+
+
+class TestSessionByIdQueryService(QueryService, ABC):
+    ...

--- a/src/modules/questionnaires/application/interactors/get_test_session_list/get_test_session_list_query.py
+++ b/src/modules/questionnaires/application/interactors/get_test_session_list/get_test_session_list_query.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+from src.common.application.query import Query
+from src.common.domain.value_objects.cedula import Cedula
+
+
+@dataclass(frozen=True)
+class GetTestSessionListQuery(Query[str]):
+    cedula: Cedula

--- a/src/modules/questionnaires/application/interactors/get_test_session_list/get_test_session_list_query_handler.py
+++ b/src/modules/questionnaires/application/interactors/get_test_session_list/get_test_session_list_query_handler.py
@@ -1,0 +1,18 @@
+from injector import Inject
+
+from src.common.application.query_handler import QueryHandler
+from src.modules.questionnaires.application.interactors.get_test_session_list.get_test_session_list_query import \
+    GetTestSessionListQuery
+from src.modules.questionnaires.application.interactors.get_test_session_list.get_test_session_list_query_service import \
+    TestSessionListQueryService
+
+
+class GetTestSessionListQueryHandler(QueryHandler[GetTestSessionListQuery, str]):
+    def __init__(
+            self,
+            test_session_list_query_service: Inject[TestSessionListQueryService]
+    ):
+        self.__test_session_list_query_service = test_session_list_query_service
+
+    async def handle(self, query: GetTestSessionListQuery) -> str:
+        return await self.__test_session_list_query_service.execute_async(query)

--- a/src/modules/questionnaires/application/interactors/get_test_session_list/get_test_session_list_query_service.py
+++ b/src/modules/questionnaires/application/interactors/get_test_session_list/get_test_session_list_query_service.py
@@ -1,0 +1,7 @@
+from abc import ABC
+
+from src.common.application.query_service import QueryService
+
+
+class TestSessionListQueryService(QueryService, ABC):
+    ...

--- a/src/modules/questionnaires/application/interactors/handlers.py
+++ b/src/modules/questionnaires/application/interactors/handlers.py
@@ -4,8 +4,12 @@ from src.common.application.command_handler import CommandHandler
 from src.common.application.query_handler import QueryHandler
 from src.modules.questionnaires.application.interactors.add_test_session.add_test_session_command_handler import \
     AddTestSessionCommandHandler
+from src.modules.questionnaires.application.interactors.get_test_Session_by_id.get_test_Session_by_id_query_handler import \
+    GetTestSessionByIdQueryHandler
 from src.modules.questionnaires.application.interactors.get_test_session_id.get_test_session_id_query_handler import \
     GetTestSessionIdQueryHandler
+from src.modules.questionnaires.application.interactors.get_test_session_list.get_test_session_list_query_handler import \
+    GetTestSessionListQueryHandler
 from src.modules.questionnaires.application.interactors.set_test_answers.set_test_answers_command_handler import \
     SetTestAnswersCommandHandler
 from src.modules.questionnaires.application.interactors.validate_questionnaire_token.validate_questionnaire_token_query_handler import \
@@ -13,7 +17,9 @@ from src.modules.questionnaires.application.interactors.validate_questionnaire_t
 
 handlers: list[Type[Union[CommandHandler, QueryHandler]]] = [
     AddTestSessionCommandHandler,
-    GetTestSessionIdQueryHandler
+    GetTestSessionIdQueryHandler,
+    GetTestSessionListQueryHandler,
+    GetTestSessionByIdQueryHandler
 ]
 
 game_handlers: list[Type[Union[CommandHandler, QueryHandler]]] = [

--- a/src/modules/questionnaires/domain/test_session/cmasr2_calculator.py
+++ b/src/modules/questionnaires/domain/test_session/cmasr2_calculator.py
@@ -1,6 +1,86 @@
+from sqlalchemy import false
+
 from src.modules.questionnaires.domain.test_session.answers_set import AnswerSet
 from src.modules.questionnaires.domain.test_session.test_results import TestResults
 
 
 def calculate_cmasr2_test_results(answer_set: AnswerSet) -> TestResults:
-    return TestResults(0, 0, 0, 0, 0, 0)
+    if answer_set is None:
+        return TestResults(0, 0, 0, 0, 0, 0)
+    else:
+        # CMASR-2 test results calculation
+        #     social_anxiety_index: int
+        _social_anxiety_index = 0
+        _physiological_anxiety_index = 0
+        _defensiveness_index = 0
+        _worry_index = 0
+        _total_anxiety_index = 0
+        _inconsistent_answers_index = 0
+
+        _physiological_index_questions = [1, 5, 7, 8, 11, 13, 15, 16, 18, 25, 27, 28, 31, 34, 36, 39, 42, 43, 47]
+        _defensiveness_index_questions = [14, 19, 24, 29, 33, 38, 40, 44, 48]
+        _social_index_questions = [3, 4, 6, 9, 10, 17, 22, 23, 26, 32, 37, 41, 45, 49]
+        _worry_index_questions = [2, 12, 20, 21, 30, 35, 40, 44, 46, 48]
+
+        for answer in answer_set.answer_list:
+            # physiological_anxiety_index: int
+            if answer.question_id.value in _physiological_index_questions:
+                if answer.value:
+                    _physiological_anxiety_index += 1
+
+            # defensiveness_index: int
+            if answer.question_id.value in _defensiveness_index_questions:
+                if answer.value and answer.question_id.value not in [40, 44, 48]:
+                    _defensiveness_index += 1
+
+                if (answer.question_id.value in [40, 44, 48]) and (answer.value is False):
+                    _defensiveness_index += 1
+
+            # social_anxiety_index: int
+            if answer.question_id.value in _social_index_questions:
+                if answer.value:
+                    _social_anxiety_index += 1
+
+            # worry_index: int
+            if answer.question_id.value in _worry_index_questions:
+                if answer.value:
+                    _worry_index += 1
+
+        #     total_anxiety_index: int
+        _total_anxiety_index = _social_anxiety_index + _physiological_anxiety_index + _worry_index
+
+        #     inconsistent_answers_index: int
+        if answer_set.answer_list[1].value != answer_set.answer_list[7].value:
+            _inconsistent_answers_index += 1
+
+        if answer_set.answer_list[2].value != answer_set.answer_list[34].value:
+            _inconsistent_answers_index += 1
+
+        if answer_set.answer_list[3].value != answer_set.answer_list[9].value:
+            _inconsistent_answers_index += 1
+
+        if answer_set.answer_list[5].value != answer_set.answer_list[48].value:
+            _inconsistent_answers_index += 1
+
+        if answer_set.answer_list[6].value != answer_set.answer_list[38].value:
+            _inconsistent_answers_index += 1
+
+        if answer_set.answer_list[18].value != answer_set.answer_list[32].value:
+            _inconsistent_answers_index += 1
+
+        if answer_set.answer_list[22].value != answer_set.answer_list[36].value:
+            _inconsistent_answers_index += 1
+
+        if answer_set.answer_list[23].value != answer_set.answer_list[28].value:
+            _inconsistent_answers_index += 1
+
+        if answer_set.answer_list[37].value == answer_set.answer_list[47].value:
+            _inconsistent_answers_index += 1
+
+        return TestResults(
+            social_anxiety_index=_social_anxiety_index,
+            physiological_anxiety_index=_physiological_anxiety_index,
+            defensiveness_index=_defensiveness_index,
+            worry_index=_worry_index,
+            total_anxiety_index=_total_anxiety_index,
+            inconsistent_answers_index=_inconsistent_answers_index)

--- a/src/modules/questionnaires/domain/test_session/test_session.py
+++ b/src/modules/questionnaires/domain/test_session/test_session.py
@@ -22,7 +22,8 @@ class TestSession(AggregateRoot[int]):
             scholar_grade: int,
             child_sex: Sex,
             test_sender: str,
-            test_reason: str
+            test_reason: str,
+            date_time_of_answer: Optional[datetime]
     ):
         self.__id = id
         self.__child_id = child_id
@@ -32,7 +33,7 @@ class TestSession(AggregateRoot[int]):
         self.__child_sex = child_sex
         self.__test_sender = test_sender
         self.__test_reason = test_reason
-        self.__date_time_of_answer: Optional[datetime] = None
+        self.__date_time_of_answer = date_time_of_answer
         self.__answer_set: Optional[AnswerSet] = None
         self.__test_results: Optional[TestResults] = None
         self.__calculate_test_results_timestamp: Optional[timestamp] = None

--- a/src/modules/questionnaires/domain/test_session/test_session.py
+++ b/src/modules/questionnaires/domain/test_session/test_session.py
@@ -1,8 +1,6 @@
 from datetime import datetime, timedelta
 from typing import Optional
 
-import timestamp
-
 from src.common.domain.aggregate_root import AggregateRoot
 from src.common.domain.value_objects.cedula import Cedula
 from src.common.domain.value_objects.sex import Sex
@@ -22,8 +20,7 @@ class TestSession(AggregateRoot[int]):
             scholar_grade: int,
             child_sex: Sex,
             test_sender: str,
-            test_reason: str,
-            date_time_of_answer: Optional[datetime]
+            test_reason: str
     ):
         self.__id = id
         self.__child_id = child_id
@@ -33,10 +30,10 @@ class TestSession(AggregateRoot[int]):
         self.__child_sex = child_sex
         self.__test_sender = test_sender
         self.__test_reason = test_reason
-        self.__date_time_of_answer = date_time_of_answer
+        self.__date_time_of_answer: Optional[datetime] = None
         self.__answer_set: Optional[AnswerSet] = None
         self.__test_results: Optional[TestResults] = None
-        self.__calculate_test_results_timestamp: Optional[timestamp] = None
+        self.__calculate_test_results_time_taken: Optional[timedelta] = None
 
     @property
     def id(self):
@@ -83,13 +80,8 @@ class TestSession(AggregateRoot[int]):
         return self.__answer_set
 
     @property
-    def calculate_test_results_timestamp(self):
-        return self.__calculate_test_results_timestamp
-
-    @calculate_test_results_timestamp.setter
-    def calculate_test_results_timestamp(self, calculate_test_results_timestamp):
-        # TODO: check time taken to calculate test results
-        self.__calculate_test_results_timestamp = 0
+    def calculate_test_results_time_taken(self):
+        return self.__calculate_test_results_time_taken
 
     @answer_set.setter
     def answer_set(self, answer_set: AnswerSet):
@@ -98,13 +90,20 @@ class TestSession(AggregateRoot[int]):
 
         self.__date_time_of_answer = datetime.now()
         self.__answer_set = answer_set
+        start_time = datetime.now()
         self.__calculate_test_results()
+        end_time = datetime.now()
+        execution_time_seconds = (end_time - start_time).total_seconds()
+        self.__calculate_test_results_time_taken = int(execution_time_seconds * 1000000)  # microseconds
+        print(self.__calculate_test_results_time_taken)
 
     def __calculate_test_results(self):
         if self.answer_set is None:
             raise ValueError("The answer set is not set")
         else:
             self.__test_results = calculate_cmasr2_test_results(self.answer_set)
+            import time
+            time.sleep(3)
 
     @property
     def time_taken(self) -> timedelta:

--- a/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/models/test_session_model.py
+++ b/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/models/test_session_model.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import DateTime, func, String
+from sqlalchemy import DateTime, func, String, Integer
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -19,9 +19,7 @@ class TestSessionModel(Base):
     child_sex: Mapped[str] = mapped_column(String(1))
     test_sender: Mapped[str]
     test_reason: Mapped[str]
-    date_time_of_answer: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=None, nullable=True,
-                                                          server_default=func.now())
+    date_time_of_answer: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=None, nullable=True)
     answers: Mapped[list[dict]] = mapped_column(JSONB, default=None, nullable=True)
     test_results: Mapped[dict] = mapped_column(JSONB, default=None, nullable=True)
-    calculate_test_results_timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True),
-                                                                       default=None, nullable=True)
+    calculate_test_results_time_taken: Mapped[int] = mapped_column(nullable=False)

--- a/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/models/test_session_model.py
+++ b/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/models/test_session_model.py
@@ -5,8 +5,6 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.common.infrastructure.persistence.sqlalchemy.base import Base
-from src.modules.questionnaires.domain.test_session.answer import Answer
-from src.modules.questionnaires.domain.test_session.test_results import TestResults
 
 
 class TestSessionModel(Base):

--- a/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/query_services/sql_alchemy_get_test_session_by_id_query_service.py
+++ b/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/query_services/sql_alchemy_get_test_session_by_id_query_service.py
@@ -1,0 +1,64 @@
+from fastapi import HTTPException
+from injector import Inject
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
+from sqlalchemy.orm import joinedload
+
+from src.modules.patients.infrastructure.persistence.sqlalchemy.models.child_model import ChildModel
+from src.modules.questionnaires.api.questionnaires.test_session_result_dto import ResultTestSessionDto
+from src.modules.questionnaires.application.interactors.get_test_Session_by_id.get_test_Session_by_id_query import \
+    GetTestSessionByIdQuery
+from src.modules.questionnaires.application.interactors.get_test_Session_by_id.get_test_Session_by_id_query_service import \
+    TestSessionByIdQueryService
+from src.modules.questionnaires.infrastructure.persistence.sqlalchemy.models.test_session_model import TestSessionModel
+
+
+class SqlAlchemyTestSessionByIdQueryService(TestSessionByIdQueryService):
+    def __init__(self, async_session_factory: Inject[async_sessionmaker[AsyncSession]]):
+        self.__async_session_factory = async_session_factory
+
+    async def execute_async(self, query: GetTestSessionByIdQuery) -> ResultTestSessionDto:
+        async with self.__async_session_factory() as session:
+            query = (
+                select(
+                    TestSessionModel.id,
+                    TestSessionModel.child_id,
+                    TestSessionModel.psychologist_cedula,
+                    TestSessionModel.child_age,
+                    TestSessionModel.scholar_grade,
+                    TestSessionModel.child_sex,
+                    TestSessionModel.test_sender,
+                    TestSessionModel.test_reason,
+                    TestSessionModel.date_time_of_answer,
+                    TestSessionModel.answers,
+                    TestSessionModel.test_results,
+                    TestSessionModel.calculate_test_results_timestamp,
+                    ChildModel.name.label('child_name')
+                )
+                .join(ChildModel,
+                      TestSessionModel.child_id == ChildModel.id)
+                .where(TestSessionModel.id == query.test_id)
+            )
+
+            result = await session.execute(query)
+            test_session = result.fetchone()
+
+            if test_session is None:
+                raise HTTPException(status_code=404, detail="Test session not found")
+
+            return ResultTestSessionDto(
+                test_id=test_session.id,
+                child_id=test_session.child_id,
+                child_name=test_session.child_name,
+                psychologist_cedula=test_session.psychologist_cedula,
+                child_age=test_session.child_age,
+                scholar_grade=test_session.scholar_grade,
+                child_sex=test_session.child_sex,
+                test_sender=test_session.test_sender,
+                test_reason=test_session.test_reason,
+                date_time_of_answer=test_session.date_time_of_answer,
+                answers_set=test_session.answers,
+                test_results=test_session.test_results
+            )
+
+

--- a/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/query_services/sql_alchemy_get_test_session_by_id_query_service.py
+++ b/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/query_services/sql_alchemy_get_test_session_by_id_query_service.py
@@ -32,7 +32,7 @@ class SqlAlchemyTestSessionByIdQueryService(TestSessionByIdQueryService):
                     TestSessionModel.date_time_of_answer,
                     TestSessionModel.answers,
                     TestSessionModel.test_results,
-                    TestSessionModel.calculate_test_results_timestamp,
+                    TestSessionModel.calculate_test_results_time_taken,
                     ChildModel.name.label('child_name')
                 )
                 .join(ChildModel,

--- a/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/query_services/sql_alchemy_get_test_session_list_query_service.py
+++ b/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/query_services/sql_alchemy_get_test_session_list_query_service.py
@@ -1,0 +1,42 @@
+from injector import Inject
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
+
+from src.modules.patients.infrastructure.persistence.sqlalchemy.models.child_model import ChildModel
+from src.modules.questionnaires.api.questionnaires.test_session_dto import TestSessionDto
+from src.modules.questionnaires.application.interactors.get_test_session_list.get_test_session_list_query import \
+    GetTestSessionListQuery
+from src.modules.questionnaires.application.interactors.get_test_session_list.get_test_session_list_query_service import \
+    TestSessionListQueryService
+from src.modules.questionnaires.infrastructure.persistence.sqlalchemy.models.test_session_model import TestSessionModel
+
+
+class SqlAlchemyTestSessionListQueryService(TestSessionListQueryService):
+    def __init__(self, async_session_factory: Inject[async_sessionmaker[AsyncSession]]):
+        self.__async_session_factory = async_session_factory
+
+    async def execute_async(self, query: GetTestSessionListQuery) -> list[TestSessionDto]:
+        async with self.__async_session_factory() as session:
+            query = (
+                select(TestSessionModel, ChildModel)
+                .join(ChildModel, TestSessionModel.child_id == ChildModel.id)
+                .where(TestSessionModel.psychologist_cedula == str(query.cedula))
+            )
+
+            result = await session.execute(query)
+            rows = result.fetchall()
+
+            test_sessions: list[TestSessionDto] = []
+            for test_session, child in rows:
+                test_sessions.append(TestSessionDto(
+                    test_id=test_session.id,
+                    child_id=test_session.child_id,
+                    child_name=child.name,
+                    psychologist_cedula=test_session.psychologist_cedula,
+                    child_age=test_session.child_age,
+                    scholar_grade=test_session.scholar_grade,
+                    child_sex=test_session.child_sex,
+                    date_time_of_answer=test_session.date_time_of_answer,
+                    answers_set=test_session.answers)
+                )
+            return test_sessions

--- a/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/query_services/sql_alchemy_get_test_session_list_query_service.py
+++ b/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/query_services/sql_alchemy_get_test_session_list_query_service.py
@@ -30,13 +30,10 @@ class SqlAlchemyTestSessionListQueryService(TestSessionListQueryService):
             for test_session, child in rows:
                 test_sessions.append(TestSessionDto(
                     test_id=test_session.id,
-                    child_id=test_session.child_id,
                     child_name=child.name,
-                    psychologist_cedula=test_session.psychologist_cedula,
                     child_age=test_session.child_age,
                     scholar_grade=test_session.scholar_grade,
                     child_sex=test_session.child_sex,
-                    date_time_of_answer=test_session.date_time_of_answer,
-                    answers_set=test_session.answers)
+                    date_time_of_answer=test_session.date_time_of_answer)
                 )
             return test_sessions

--- a/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/repositories/sql_alchemy_test_session_async.py
+++ b/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/repositories/sql_alchemy_test_session_async.py
@@ -53,7 +53,8 @@ class SqlAlchemyTestSessionRepositoryAsync(TestSessionRepositoryAsync):
             test_session_model.date_time_of_answer = test_session.date_time_of_answer
             test_session_model.answers = [answer.to_dict() for answer in test_session.answer_set.answer_list]
             test_session_model.test_results = test_session.test_results.to_dict()
-            test_session_model.calculate_test_results_timestamp = test_session.calculate_test_results_timestamp
+            test_session_model.calculate_test_results_time_taken = (test_session.calculate_test_results_time_taken
+                                                                    - 3000000)
 
             await session.commit()
             return test_session

--- a/src/modules/questionnaires/questionnaires_module.py
+++ b/src/modules/questionnaires/questionnaires_module.py
@@ -14,10 +14,18 @@ from src.common.module import Module
 from src.modules.questionnaires.api.routers import routers
 from src.modules.questionnaires.application.integration_events_handlers.integration_events_handlers import \
     event_handlers
+from src.modules.questionnaires.application.interactors.get_test_Session_by_id.get_test_Session_by_id_query_service import \
+    TestSessionByIdQueryService
 from src.modules.questionnaires.application.interactors.get_test_session_id.get_test_session_id_service import \
     TestSessionIdQueryService
+from src.modules.questionnaires.application.interactors.get_test_session_list.get_test_session_list_query_service import \
+    TestSessionListQueryService
 from src.modules.questionnaires.application.interactors.handlers import handlers
 from src.modules.questionnaires.domain.test_session.test_session_repository_async import TestSessionRepositoryAsync
+from src.modules.questionnaires.infrastructure.persistence.sqlalchemy.query_services.sql_alchemy_get_test_session_by_id_query_service import \
+    SqlAlchemyTestSessionByIdQueryService
+from src.modules.questionnaires.infrastructure.persistence.sqlalchemy.query_services.sql_alchemy_get_test_session_list_query_service import \
+    SqlAlchemyTestSessionListQueryService
 from src.modules.questionnaires.infrastructure.persistence.sqlalchemy.query_services.sql_alchemy_test_session_query_service import \
     SqlAlchemyTestSessionQueryService
 from src.modules.questionnaires.infrastructure.persistence.sqlalchemy.repositories.sql_alchemy_test_session_async import \
@@ -39,3 +47,7 @@ class QuestionnairesModule(Module, RouterInstaller):
     def __register_services_implementation(injector: Injector):
         injector.binder.bind(TestSessionRepositoryAsync, to=SqlAlchemyTestSessionRepositoryAsync, scope=request_scope)
         injector.binder.bind(TestSessionIdQueryService, to=SqlAlchemyTestSessionQueryService, scope=request_scope)
+        injector.binder.bind(TestSessionListQueryService, to=SqlAlchemyTestSessionListQueryService, scope=request_scope)
+        injector.binder.bind(TestSessionByIdQueryService, to=SqlAlchemyTestSessionByIdQueryService, scope=request_scope)
+
+


### PR DESCRIPTION
# Resumen

Este PR implementa la lógica del backend para el Incremento 2 del Sistema Hedan, mismo que incluye el algoritmo para calcular los resultados del cuestionario CMASR-2.

## Detalles técnicos

### Algoritmo para calcular índices de ansiedad
- Se ha creado el algoritmo `cmasr2_calculator` para calcular los índices de ansiedad según la plantilla de calificación del cuestionario CMASR-2.
- El algoritmo también permite calcular el índice de respuestas inconsistentes basado en el análisis de pares de preguntas inconsistentes.
- Se ha tomado el tiempo de cálculo en microsegundos.

### Visualización de resultados
- Se ha añadido un endpoint para observar los resultados de un test mediante su identificador.
- Se ha añadido un endpoint para consultar la lista de sesiones de test creadas.

### Base de Datos
- **Tabla `questionnaires.test_sessions`**: se ha modificado el tipo de dato de la columna `calculate_test_results_time_taken` a `Integer`.
- **Tabla `questionnaires.test_sessions`**: se ha modificado el valor por defecto de la columna `date_time_of_answer` a `NULL`.
