### PR TITLE
feat: Añade métodos para eliminar sesiones && ver enlaces de invitación

### DIFF
--- a/alembic/versions/84f17ee79218_upgrade_test_session_columns.py
+++ b/alembic/versions/84f17ee79218_upgrade_test_session_columns.py
@@ -29,6 +29,7 @@ def upgrade() -> None:
     sa.Column('child_sex', sa.String(length=1), nullable=False),
     sa.Column('test_sender', sa.String(), nullable=False),
     sa.Column('test_reason', sa.String(), nullable=False),
+    sa.Column('test_token', sa.String(), nullable=True),
     sa.Column('date_time_of_answer', sa.DateTime(timezone=True), nullable=True),
     sa.Column('answers', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
     sa.Column('test_results', postgresql.JSONB(astext_type=sa.Text()), nullable=True),

--- a/src/apps/game_api/setup.py
+++ b/src/apps/game_api/setup.py
@@ -25,7 +25,7 @@ def create_fast_api_app() -> FastAPI:
     app.add_middleware(InjectorMiddleware, injector=injector)
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["http://localhost:8060"],
+        allow_origins=["http://127.0.0.1:8060"],
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/src/modules/questionnaires/api/questionnaires/questionnaires_router.py
+++ b/src/modules/questionnaires/api/questionnaires/questionnaires_router.py
@@ -6,15 +6,21 @@ from fastapi import APIRouter
 from fastapi_injector import Injected
 from mediatr import Mediator
 
-from src.common.api.authorization import psychologist_with_cedula
+from src.common.api.authorization import psychologist_with_cedula, psychologist_only
 from src.common.domain.value_objects.cedula import Cedula
 from src.modules.questionnaires.api.questionnaires.test_session_dto import TestSessionDto
+from src.modules.questionnaires.api.questionnaires_children.validate_token_dto import ValidateTokenDto
+from src.modules.questionnaires.application.interactors.delete_test_by_id.delete_test_by_id_command import \
+    DeleteTestByIdCommand
 from src.modules.questionnaires.application.interactors.get_test_Session_by_id.get_test_Session_by_id_query import \
     GetTestSessionByIdQuery
 from src.modules.questionnaires.application.interactors.get_test_session_id.get_test_session_id_query import \
     GetTestSessionIdQuery
 from src.modules.questionnaires.application.interactors.get_test_session_list.get_test_session_list_query import \
     GetTestSessionListQuery
+from src.modules.questionnaires.application.interactors.set_test_token.set_test_token_command import SetTestTokenCommand
+from src.modules.questionnaires.application.interactors.validate_questionnaire_token.validate_questionnaire_token_query import \
+    ValidateQuestionnaireTokenQuery
 from src.modules.questionnaires.application.invitation_link.invitation_link_provider import InvitationLinkProvider
 
 router = APIRouter(prefix="/questionnaires", tags=["Questionnaires"])
@@ -35,6 +41,13 @@ async def get_token(child_id: int, psychologist_cedula: int, mediator: Mediator 
         else:
             # Generate invitation link
             token = InvitationLinkProvider.generate_token(test_session_id)
+            # Save token into database
+            stm = SetTestTokenCommand(
+                token=token,
+                test_session_id=test_session_id
+            )
+            await mediator.send_async(stm)
+            # Return invitation link
             return f"{os.getenv("GAME_URL")}/?token={token}"
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -52,11 +65,23 @@ async def get_test_sessions(psychologist_cedula: int, mediator: Mediator = Injec
 
 
 @router.get("/resultado/{test_id}")
-async def get_test_sessions(test_id: int, mediator: Mediator = Injected(Mediator)):
+async def get_test_result(test_id: int, mediator: Mediator = Injected(Mediator)):
     try:
         query = GetTestSessionByIdQuery(
             test_id=test_id
         )
         return await mediator.send_async(query)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete("/{psychologist_cedula}/{test_session_id}", dependencies=[Security(psychologist_with_cedula)])
+async def delete_test_by_id(psychologist_cedula: str, test_session_id: int, mediator: Mediator = Injected(Mediator)):
+    try:
+        query = DeleteTestByIdCommand(
+            psychologist_cedula=psychologist_cedula,
+            test_session_id=test_session_id
+        )
+        await mediator.send_async(query)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/src/modules/questionnaires/api/questionnaires/test_session_dto.py
+++ b/src/modules/questionnaires/api/questionnaires/test_session_dto.py
@@ -10,5 +10,7 @@ class TestSessionDto:
     scholar_grade: int
     child_sex: str
     date_time_of_answer: str
+    token: str
+    isTokenValid: bool
 
 

--- a/src/modules/questionnaires/application/interactors/delete_test_by_id/delete_test_by_id_command.py
+++ b/src/modules/questionnaires/application/interactors/delete_test_by_id/delete_test_by_id_command.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+from src.common.application.command import Command
+
+
+@dataclass(frozen=True)
+class DeleteTestByIdCommand(Command[None]):
+    psychologist_cedula: str
+    test_session_id: int

--- a/src/modules/questionnaires/application/interactors/delete_test_by_id/delete_test_by_id_command_handler.py
+++ b/src/modules/questionnaires/application/interactors/delete_test_by_id/delete_test_by_id_command_handler.py
@@ -1,0 +1,28 @@
+from injector import Inject
+
+from src.common.application.command_handler import CommandHandler
+from src.common.application.event_bus import EventBus
+from src.modules.questionnaires.application.interactors.delete_test_by_id.delete_test_by_id_command import \
+    DeleteTestByIdCommand
+from src.modules.questionnaires.domain.test_session.test_session_repository_async import TestSessionRepositoryAsync
+from src.modules.questionnaires.integration_events.test_session_deleted_event import TestSessionDeletedEvent
+
+
+class DeleteTestByIdCommandHandler(CommandHandler[DeleteTestByIdCommand, None]):
+    def __init__(
+            self,
+            event_bus: Inject[EventBus],
+            test_session_repository: Inject[TestSessionRepositoryAsync]
+    ):
+        self.__event_bus = event_bus
+        self.__test_session_repository = test_session_repository
+
+    async def handle(self, command: DeleteTestByIdCommand) -> None:
+        await self.__test_session_repository.delete_test_session_by_id(command.psychologist_cedula,
+                                                                       command.test_session_id)
+
+        self.__event_bus.publish(
+            TestSessionDeletedEvent(
+                test_session_id=command.test_session_id
+            )
+        )

--- a/src/modules/questionnaires/application/interactors/handlers.py
+++ b/src/modules/questionnaires/application/interactors/handlers.py
@@ -4,6 +4,8 @@ from src.common.application.command_handler import CommandHandler
 from src.common.application.query_handler import QueryHandler
 from src.modules.questionnaires.application.interactors.add_test_session.add_test_session_command_handler import \
     AddTestSessionCommandHandler
+from src.modules.questionnaires.application.interactors.delete_test_by_id.delete_test_by_id_command_handler import \
+    DeleteTestByIdCommandHandler
 from src.modules.questionnaires.application.interactors.get_test_Session_by_id.get_test_Session_by_id_query_handler import \
     GetTestSessionByIdQueryHandler
 from src.modules.questionnaires.application.interactors.get_test_session_id.get_test_session_id_query_handler import \
@@ -12,6 +14,8 @@ from src.modules.questionnaires.application.interactors.get_test_session_list.ge
     GetTestSessionListQueryHandler
 from src.modules.questionnaires.application.interactors.set_test_answers.set_test_answers_command_handler import \
     SetTestAnswersCommandHandler
+from src.modules.questionnaires.application.interactors.set_test_token.set_test_token_command_handler import \
+    SetTestTokenCommandHandler
 from src.modules.questionnaires.application.interactors.validate_questionnaire_token.validate_questionnaire_token_query_handler import \
     ValidateQuestionnaireTokenQueryHandler
 
@@ -19,7 +23,9 @@ handlers: list[Type[Union[CommandHandler, QueryHandler]]] = [
     AddTestSessionCommandHandler,
     GetTestSessionIdQueryHandler,
     GetTestSessionListQueryHandler,
-    GetTestSessionByIdQueryHandler
+    GetTestSessionByIdQueryHandler,
+    SetTestTokenCommandHandler,
+    DeleteTestByIdCommandHandler
 ]
 
 game_handlers: list[Type[Union[CommandHandler, QueryHandler]]] = [

--- a/src/modules/questionnaires/application/interactors/set_test_token/set_test_token_command.py
+++ b/src/modules/questionnaires/application/interactors/set_test_token/set_test_token_command.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+from src.common.application.command import Command
+
+
+@dataclass(frozen=True)
+class SetTestTokenCommand(Command[None]):
+    token: str
+    test_session_id: int

--- a/src/modules/questionnaires/application/interactors/set_test_token/set_test_token_command_handler.py
+++ b/src/modules/questionnaires/application/interactors/set_test_token/set_test_token_command_handler.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+from injector import Inject
+
+from src.common.application.command_handler import CommandHandler
+from src.common.application.event_bus import EventBus
+from src.modules.questionnaires.application.interactors.set_test_token.set_test_token_command import SetTestTokenCommand
+from src.modules.questionnaires.domain.test_session.test_session_repository_async import TestSessionRepositoryAsync
+
+
+class SetTestTokenCommandHandler(CommandHandler[SetTestTokenCommand, None]):
+    def __init__(
+            self,
+            event_bus: Inject[EventBus],
+            test_session_repository: Inject[TestSessionRepositoryAsync]
+    ):
+        self.__event_bus = event_bus
+        self.__test_session_repository = test_session_repository
+
+    async def handle(self, command: SetTestTokenCommand) -> None:
+        await self.__test_session_repository.set_token(
+            test_session_id=command.test_session_id,
+            token=command.token
+        )
+

--- a/src/modules/questionnaires/domain/test_session/test_session.py
+++ b/src/modules/questionnaires/domain/test_session/test_session.py
@@ -34,6 +34,7 @@ class TestSession(AggregateRoot[int]):
         self.__answer_set: Optional[AnswerSet] = None
         self.__test_results: Optional[TestResults] = None
         self.__calculate_test_results_time_taken: Optional[timedelta] = None
+        self.__test_token: Optional[str] = None
 
     @property
     def id(self):
@@ -78,6 +79,10 @@ class TestSession(AggregateRoot[int]):
     @property
     def answer_set(self):
         return self.__answer_set
+
+    @property
+    def test_token(self):
+        return self.__test_token
 
     @property
     def calculate_test_results_time_taken(self):

--- a/src/modules/questionnaires/domain/test_session/test_session_repository_async.py
+++ b/src/modules/questionnaires/domain/test_session/test_session_repository_async.py
@@ -13,3 +13,10 @@ class TestSessionRepositoryAsync(ABC):
     @abstractmethod
     async def set_answers_set(self, test_session_id: int, answer_set: AnswerSet) -> TestSession:
         pass
+
+    async def set_token(self, test_session_id: int, token: str):
+        pass
+
+    async def delete_test_session_by_id(self, psychologist_cedula: str,
+                                        test_session_id: int) -> bool:
+        pass

--- a/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/models/test_session_model.py
+++ b/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/models/test_session_model.py
@@ -19,6 +19,7 @@ class TestSessionModel(Base):
     child_sex: Mapped[str] = mapped_column(String(1))
     test_sender: Mapped[str]
     test_reason: Mapped[str]
+    test_token: Mapped[str] = mapped_column(nullable=True)
     date_time_of_answer: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=None, nullable=True)
     answers: Mapped[list[dict]] = mapped_column(JSONB, default=None, nullable=True)
     test_results: Mapped[dict] = mapped_column(JSONB, default=None, nullable=True)

--- a/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/query_services/sql_alchemy_get_test_session_list_query_service.py
+++ b/src/modules/questionnaires/infrastructure/persistence/sqlalchemy/query_services/sql_alchemy_get_test_session_list_query_service.py
@@ -8,6 +8,7 @@ from src.modules.questionnaires.application.interactors.get_test_session_list.ge
     GetTestSessionListQuery
 from src.modules.questionnaires.application.interactors.get_test_session_list.get_test_session_list_query_service import \
     TestSessionListQueryService
+from src.modules.questionnaires.application.invitation_link.invitation_link_provider import InvitationLinkProvider
 from src.modules.questionnaires.infrastructure.persistence.sqlalchemy.models.test_session_model import TestSessionModel
 
 
@@ -34,6 +35,9 @@ class SqlAlchemyTestSessionListQueryService(TestSessionListQueryService):
                     child_age=test_session.child_age,
                     scholar_grade=test_session.scholar_grade,
                     child_sex=test_session.child_sex,
-                    date_time_of_answer=test_session.date_time_of_answer)
+                    date_time_of_answer=test_session.date_time_of_answer,
+                    token=test_session.test_token,
+                    isTokenValid=InvitationLinkProvider.validate_token(test_session.test_token)
+                )
                 )
             return test_sessions

--- a/src/modules/questionnaires/integration_events/test_session_deleted_event.py
+++ b/src/modules/questionnaires/integration_events/test_session_deleted_event.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+from src.common.integration_events.integration_event import IntegrationEvent
+
+@dataclass(frozen=True)
+class TestSessionDeletedEvent(IntegrationEvent):
+    test_session_id: int

--- a/src/modules/results_analysis/application/integration_events_handlers/integration_events_handlers.py
+++ b/src/modules/results_analysis/application/integration_events_handlers/integration_events_handlers.py
@@ -3,12 +3,21 @@ from typing import List, Dict, Type
 from src.common.application.integration_event_handler import IntegrationEventHandler
 from src.common.integration_events.integration_event import IntegrationEvent
 from src.modules.questionnaires.integration_events.test_answers_submitted_event import TestAnswersSubmittedEvent
+from src.modules.questionnaires.integration_events.test_session_deleted_event import TestSessionDeletedEvent
 from src.modules.results_analysis.application.integration_events_handlers.test_answers_submitted_event_handler import \
     TestAnswersSubmittedEventHandler
+from src.modules.results_analysis.application.integration_events_handlers.test_session_deleted_event_handler import \
+    TestSessionDeletedEventHandler
 
 game_event_handlers: List[Dict[Type[IntegrationEvent], Type[IntegrationEventHandler]]] = [
     {
         TestAnswersSubmittedEvent: TestAnswersSubmittedEventHandler
+    }
+]
+
+web_app_event_handlers: List[Dict[Type[IntegrationEvent], Type[IntegrationEventHandler]]] = [
+    {
+        TestSessionDeletedEvent: TestSessionDeletedEventHandler
     }
 ]
 

--- a/src/modules/results_analysis/application/integration_events_handlers/test_session_deleted_event_handler.py
+++ b/src/modules/results_analysis/application/integration_events_handlers/test_session_deleted_event_handler.py
@@ -1,0 +1,15 @@
+from injector import Inject
+
+from src.common.application.integration_event_handler import IntegrationEventHandler
+from src.modules.questionnaires.integration_events.test_session_deleted_event import TestSessionDeletedEvent
+from src.modules.results_analysis.domain.test_report.test_report_repository_async import TestReportRepositoryAsync
+
+
+class TestSessionDeletedEventHandler(IntegrationEventHandler[TestSessionDeletedEvent, None]):
+    def __init__(self, repository: Inject[TestReportRepositoryAsync]):
+        self.repository = repository
+
+    async def handle(self, event: TestSessionDeletedEvent) -> bool:
+        # Delete test report associated with test session
+        await self.repository.delete_test_report_by_test_session_id(event.test_session_id)
+        return True

--- a/src/modules/results_analysis/domain/test_report/test_report_repository_async.py
+++ b/src/modules/results_analysis/domain/test_report/test_report_repository_async.py
@@ -7,3 +7,7 @@ class TestReportRepositoryAsync(ABC):
     @abstractmethod
     async def add_test_report(self, test_report: TestReport):
         ...
+
+    @abstractmethod
+    async def delete_test_report_by_test_session_id(self, test_session_id):
+        ...

--- a/src/modules/results_analysis/game_results_analysis_module.py
+++ b/src/modules/results_analysis/game_results_analysis_module.py
@@ -11,7 +11,7 @@ from src.common.infrastructure.bus.memory.in_memory_event_bus import InMemoryEve
 from src.common.module import Module
 from src.modules.results_analysis.api.routers import routers
 from src.modules.results_analysis.application.integration_events_handlers.integration_events_handlers import \
-    game_event_handlers
+    game_event_handlers, web_app_event_handlers
 from src.modules.results_analysis.domain.test_report.test_report_repository_async import TestReportRepositoryAsync
 from src.modules.results_analysis.infrastructure.persistence.sqlalchemy.repositories.sql_alchemy_test_report_repository_async import \
     SqlAlchemyTestReportRepositoryAsync

--- a/src/modules/results_analysis/infrastructure/persistence/sqlalchemy/repositories/sql_alchemy_test_report_repository_async.py
+++ b/src/modules/results_analysis/infrastructure/persistence/sqlalchemy/repositories/sql_alchemy_test_report_repository_async.py
@@ -1,4 +1,5 @@
 from injector import Inject
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
 
 from src.modules.results_analysis.domain.test_report.test_report import TestReport
@@ -25,3 +26,12 @@ class SqlAlchemyTestReportRepositoryAsync(TestReportRepositoryAsync):
         async with self.__async_session_factory() as session:
             session.add(test_report_model)
             await session.commit()
+
+    async def delete_test_report_by_test_session_id(self, test_session_id):
+        async with self.__async_session_factory() as session:
+            query = select(TestReportModel).filter(TestReportModel.test_session_id == test_session_id)
+            result = await session.execute(query)
+            test_report_model = result.scalars().first()
+            if test_report_model:
+                await session.delete(test_report_model)
+                await session.commit()

--- a/src/modules/results_analysis/results_analysis_module.py
+++ b/src/modules/results_analysis/results_analysis_module.py
@@ -6,14 +6,22 @@ from injector import Injector
 from mediatr import Mediator
 
 from src.common.api.router_installer import RouterInstaller
+from src.common.application.event_bus import EventBus
+from src.common.event_bus_setup import register_event_bus_handlers
+from src.common.infrastructure.bus.memory.in_memory_event_bus import InMemoryEventBus
 from src.common.mediator_setup import register_mediator_handlers
 from src.common.module import Module
 from src.modules.results_analysis.api.routers import routers
+from src.modules.results_analysis.application.integration_events_handlers.integration_events_handlers import \
+    web_app_event_handlers
 from src.modules.results_analysis.application.interactors.get_test_response.get_tests_reports_query_service import \
     GetTestsReportsQueryService
 from src.modules.results_analysis.application.interactors.handlers import handlers
+from src.modules.results_analysis.domain.test_report.test_report_repository_async import TestReportRepositoryAsync
 from src.modules.results_analysis.infrastructure.persistence.sqlalchemy.query_services.sql_alchemy_get_tests_resports_query_service import \
     SqlAlchemyGetTestsReportsQueryService
+from src.modules.results_analysis.infrastructure.persistence.sqlalchemy.repositories.sql_alchemy_test_report_repository_async import \
+    SqlAlchemyTestReportRepositoryAsync
 
 
 class ResultsAnalysisModule(Module, RouterInstaller):
@@ -21,6 +29,7 @@ class ResultsAnalysisModule(Module, RouterInstaller):
     def install(injector: Injector) -> None:
         ResultsAnalysisModule.__register_services_implementation(injector)
         register_mediator_handlers(injector.get(Mediator), handlers)
+        register_event_bus_handlers(cast(InMemoryEventBus, injector.get(EventBus)), web_app_event_handlers)
 
     @staticmethod
     def install_routers(fast_api_app: FastAPI):
@@ -30,3 +39,4 @@ class ResultsAnalysisModule(Module, RouterInstaller):
     def __register_services_implementation(injector: Injector):
         injector.binder.bind(GetTestsReportsQueryService, to=SqlAlchemyGetTestsReportsQueryService,
                              scope=request_scope)
+        injector.binder.bind(TestReportRepositoryAsync, to=SqlAlchemyTestReportRepositoryAsync, scope=request_scope)


### PR DESCRIPTION
# Resumen

Este PR implementa la lógica en el backend  del Sistema Hedan, misma que incluye métodos para eliminar sesiones de test, almacenar tokens y ver enlaces de invitación. 

## Detalles técnicos

### Eliminar sesiones de test
- Se ha creado un endpoint que permite eliminar una sesión de test tomando como argumento su id. 
- Este método emite un evento en el módulo "questionnaries" con el id de la sesión eliminada. 
- El módulo "results_analysis" maneja el evento y elimina la copia de los resultados de la sesión eliminada. 

### Ver enlaces de invitación
- Al generar un test, se almacena el enlace de invitación en el registro del test creado en la base de datos. 

### Base de Datos
- **Tabla `questionnaires.test_sessions`**: Se ha añadido una nueva columna para almacenar los tokens de invitación. 
